### PR TITLE
Support RPM based Linux systems, alternate MagicMirror home, alternate DISPLAY

### DIFF
--- a/installer/postinstall.sh
+++ b/installer/postinstall.sh
@@ -59,7 +59,7 @@ if [ "$screen_saver_running." != "." ]; then
         gsettings set org.mate.screensaver idle-activation-enabled false	 2>/dev/null
         gsettings set org.mate.screensaver lock_delay 0	 2>/dev/null
      echo " $screen_saver_running disabled"
-     DISPLAY=:0  mate-screensaver  >/dev/null 2>&1 &
+     DISPLAY=${DISPLAY:=:0} mate-screensaver  >/dev/null 2>&1 &
      ;;
    gnome-screensaver) echo 'Found: gnome screen saver'
      gnome_screensaver-command -d >/dev/null 2>&1
@@ -126,7 +126,7 @@ if [ -d "/etc/xdg/lxsession/LXDE-pi" ]; then
     # turn it off for the future
     sudo su -c "echo -e '@xset s noblank\n@xset s off\n@xset -dpms' >> /etc/xdg/lxsession/LXDE-pi/autostart"
     # turn it off now
-    export DISPLAY=:0; xset s noblank;xset s off;xset -dpms
+    export DISPLAY=${DISPLAY:=:0}; xset s noblank;xset s off;xset -dpms
   else
     echo "lxsession screen saver already disabled"
   fi

--- a/installer/preinstall.sh
+++ b/installer/preinstall.sh
@@ -66,11 +66,34 @@ else
 fi
 
 echo
-# check dependencies
-dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
-Installer_info "Checking all dependencies..."
-Installer_check_dependencies
-Installer_success "All Dependencies needed are installed !"
+# Check dependencies
+# Required packages on Debian based systems
+deb_dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
+# Required packages on RPM based systems
+rpm_dependencies=(blas-devel file-libs vlc wget autoconf automake binutils bison flex gcc gcc-c++ glibc-devel libtool make pkgconf strace byacc ccache cscope ctags elfutils indent ltrace perf valgrind systemd-devel libudev-devel libcec)
+# Check dependencies
+if [ "${debian}" ]
+then
+  dependencies=( "${deb_dependencies[@]}" )
+else
+  if [ "${have_dnf}" ]
+  then
+    dependencies=( "${rpm_dependencies[@]}" )
+  else
+    if [ "${have_yum}" ]
+    then
+      dependencies=( "${rpm_dependencies[@]}" )
+    else
+      dependencies=( "${deb_dependencies[@]}" )
+    fi
+  fi
+fi
+
+[ "${__NO_DEP_CHECK__}" ] || {
+  Installer_info "Checking all dependencies..."
+  Installer_check_dependencies
+  Installer_success "All Dependencies needed are installed !"
+}
 
 echo
 # apply @sdetweil fix

--- a/installer/rebuild.sh
+++ b/installer/rebuild.sh
@@ -46,14 +46,61 @@ Installer_update_dependencies () {
 }
 
 echo
-# check dependencies
-dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
-Installer_info "Update all dependencies..."
-Installer_update_dependencies
-Installer_success "All Dependencies needed are updated !"
+# Check platform compatibility
+Installer_info "Checking OS..."
+Installer_checkOS
+Installer_success "OS Detected: $OSTYPE ($os_name $os_version $arch)"
 
+echo
+# Check dependencies
+# Required packages on Debian based systems
+deb_dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
+# Required packages on RPM based systems
+rpm_dependencies=(blas-devel file-libs vlc wget autoconf automake binutils bison flex gcc gcc-c++ glibc-devel libtool make pkgconf strace byacc ccache cscope ctags elfutils indent ltrace perf valgrind systemd-devel libudev-devel libcec)
+# Check dependencies
+if [ "${debian}" ]
+then
+  dependencies=( "${deb_dependencies[@]}" )
+else
+  if [ "${have_dnf}" ]
+  then
+    dependencies=( "${rpm_dependencies[@]}" )
+  else
+    if [ "${have_yum}" ]
+    then
+      dependencies=( "${rpm_dependencies[@]}" )
+    else
+      dependencies=( "${deb_dependencies[@]}" )
+    fi
+  fi
+fi
 
-cd ~/MagicMirror/modules/MMM-GoogleAssistant
+[ "${__NO_DEP_CHECK__}" ] || {
+  Installer_info "Update all dependencies..."
+  Installer_update_dependencies
+  Installer_success "All Dependencies needed are updated !"
+}
+
+MMHOME="${HOME}/MagicMirror"
+[ -d ${MMHOME}/modules/MMM-GoogleAssistant ] || {
+  MMHOME=
+  for homedir in /usr/local /home/*
+  do
+    [ "${homedir}" == "/home/*" ] && continue
+    [ -d ${homedir}/MagicMirror/modules/MMM-GoogleAssistant ] && {
+      MMHOME="${homedir}/MagicMirror"
+      break
+    }
+  done
+}
+
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-GoogleAssistant
+else
+  cd ~/MagicMirror/modules/MMM-GoogleAssistant
+fi
+
 echo
 Installer_info "Deleting: package-lock.json node_modules" 
 rm -rf package.json package-lock.json node_modules

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -41,13 +41,61 @@ Installer_update_dependencies () {
 }
 
 echo
-# check dependencies
-dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
-Installer_info "Update all dependencies..."
-Installer_update_dependencies
-Installer_success "All Dependencies needed are updated !"
+# Check platform compatibility
+Installer_info "Checking OS..."
+Installer_checkOS
+Installer_success "OS Detected: $OSTYPE ($os_name $os_version $arch)"
 
-cd ~/MagicMirror/modules/MMM-GoogleAssistant
+echo
+# Check dependencies
+# Required packages on Debian based systems
+deb_dependencies=(wget unclutter build-essential vlc libmagic-dev libatlas-base-dev cec-utils libudev-dev)
+# Required packages on RPM based systems
+rpm_dependencies=(blas-devel file-libs vlc wget autoconf automake binutils bison flex gcc gcc-c++ glibc-devel libtool make pkgconf strace byacc ccache cscope ctags elfutils indent ltrace perf valgrind systemd-devel libudev-devel libcec)
+# Check dependencies
+if [ "${debian}" ]
+then
+  dependencies=( "${deb_dependencies[@]}" )
+else
+  if [ "${have_dnf}" ]
+  then
+    dependencies=( "${rpm_dependencies[@]}" )
+  else
+    if [ "${have_yum}" ]
+    then
+      dependencies=( "${rpm_dependencies[@]}" )
+    else
+      dependencies=( "${deb_dependencies[@]}" )
+    fi
+  fi
+fi
+
+[ "${__NO_DEP_CHECK__}" ] || {
+  Installer_info "Update all dependencies..."
+  Installer_update_dependencies
+  Installer_success "All Dependencies needed are updated !"
+}
+
+MMHOME="${HOME}/MagicMirror"
+[ -d ${MMHOME}/modules/MMM-GoogleAssistant ] || {
+  MMHOME=
+  for homedir in /usr/local /home/*
+  do
+    [ "${homedir}" == "/home/*" ] && continue
+    [ -d ${homedir}/MagicMirror/modules/MMM-GoogleAssistant ] && {
+      MMHOME="${homedir}/MagicMirror"
+      break
+    }
+  done
+}
+
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-GoogleAssistant
+else
+  cd ~/MagicMirror/modules/MMM-GoogleAssistant
+fi
+
 # deleting package.json because npm install add/update package
 rm -f package.json package-lock.json
 
@@ -57,12 +105,23 @@ git reset --hard HEAD
 git pull
 #fresh package.json
 git checkout package.json
-cd ~/MagicMirror/modules/MMM-GoogleAssistant/node_modules
+
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-GoogleAssistant/node_modules
+else
+  cd ~/MagicMirror/modules/MMM-GoogleAssistant/node_modules
+fi
 
 Installer_info "Deleting ALL @bugsounet libraries..."
 
 rm -rf @bugsounet
-cd ~/MagicMirror/modules/MMM-GoogleAssistant
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-GoogleAssistant
+else
+  cd ~/MagicMirror/modules/MMM-GoogleAssistant
+fi
 
 Installer_info "Ready for Installing..."
 


### PR DESCRIPTION
This pull request includes changes to support installation on RPM based Linux systems, MagicMirror installations in locations other than ~/MagicMirror, and X11 DISPLAY settings other than :0. These changes were made to the `prod` branch but similar changes apply to the v4.x branch and I hope to submit those soon.

I realize the primary focus right now is on v4.x development but I needed these changes for my distribution of the `MirrorCommand` package. Currently I am using my fork for that package so it is not critical that these changes get merged but of course it would make it easier for my installs to track any further improvements in the v3 code.

I also have similar changes for MMM-Detector and MMM-TelegramBot, two other modules I incorporate into the MirrorCommand installation. I'll submit pull requests for those as well. Let me know if these seem satisfactory or if there are better ways to accomplish these changes. Extending support for RPM based Linux systems may not seem desirable and it does require some work but I've been able to deploy MagicMirror and all the modules I use on Fedora Linux successfully after making these types of changes. The risk is, I believe, fairly low since the changes are not complicated. Still, it's your call as to whether you wish to extend support beyond `apt-get` Debian installs.

Update: I say these changes are not complicated and the actual code is not complicated but figuring out which RPMs to list as dependencies was fairly difficult. This is the one area of this pull request that may need tweaking. My guess is that some of the packages listed in the RPM dependencies may not be required or that there may be some simpler way to express these dependencies. But, my tests were successful with these.